### PR TITLE
feat: Add keyboard shortcut support for MCQ solving

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,8 @@
     "activeTab",
     "storage",
     "scripting",
-    "tabs"
+    "tabs",
+    "notifications"
   ],
   
   "host_permissions": [
@@ -32,6 +33,16 @@
   "action": {
     "default_popup": "popup.html",
     "default_title": "MCQ Solver"
+  },
+  
+  "commands": {
+    "solve-mcq": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+S",
+        "mac": "Command+Shift+S"
+      },
+      "description": "Solve MCQ questions on current page"
+    }
   },
   
   "web_accessible_resources": [


### PR DESCRIPTION
- Add Ctrl+Shift+S (Cmd+Shift+S on Mac) keyboard shortcut to trigger MCQ solving
- Update manifest.json with commands configuration and notifications permission
- Enhance background.js with keyboard command listener and notification support
- Enable users to solve MCQs without opening extension popup
- Add desktop notifications for success/error feedback

Resolves the need for quick MCQ solving via keyboard shortcuts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a keyboard shortcut (Ctrl+Shift+S or Command+Shift+S) to quickly trigger the "Solve MCQ" action on the current page.
  * Users will receive notifications for success or error events related to the shortcut action.

* **Chores**
  * Updated extension permissions to support notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->